### PR TITLE
Update env.sh to install missing packages

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -19,3 +19,6 @@ pip install fairseq
 
 # Uninstall nvidia-cublas-cu11 if there exist some bugs about CUDA version
 # pip uninstall nvidia-cublas-cu11
+
+# Addition by Wesley Bian October 2024
+pip install json5 tgt


### PR DESCRIPTION
When I ran inference from audio of the Amphion vocoder, I got errors that the json5 and tgt pip packages were not installed. After installing those, the vocoder worked as expected. I made an edit to the env.sh file to install them with everything else. 